### PR TITLE
chore: Display created and updated timestamps of buckets

### DIFF
--- a/src/LDESStore.ts
+++ b/src/LDESStore.ts
@@ -19,7 +19,7 @@ import {
     trimLeadingSlashes,
 } from "@solid/community-server";
 import { Quad, Quad_Object } from "@rdfjs/types";
-import { CacheDirectives, LDES, Member, RDF, TREE, VOID } from "@treecg/types";
+import { CacheDirectives, LDES, Member, RDF, TREE, VOID, XSD } from "@treecg/types";
 import { cacheToLiteral, getShapeQuads } from "./util/utils";
 import { DataFactory } from "n3";
 import { PrefixView } from "./PrefixView";
@@ -178,6 +178,7 @@ export class LDESStore implements ResourceStore {
         // Note: this was before: const normalizedIDPath = decodeURIComponent(identifier.path);
         const normalizedIDPath = identifier.path;
 
+        const timestamps = await fragment.getTimestamps();
         quads.push(
             quad(
                 namedNode(normalizedIDPath),
@@ -188,6 +189,16 @@ export class LDESStore implements ResourceStore {
                 namedNode(normalizedIDPath),
                 TREE.terms.custom("viewDescription"),
                 viewDescriptionId,
+            ),
+            quad(
+                namedNode(normalizedIDPath),
+                namedNode("http://purl.org/dc/terms/created"),
+                literal(new Date(timestamps.created).toISOString(), namedNode(XSD.dateTime)),
+            ),
+            quad(
+                namedNode(normalizedIDPath),
+                namedNode("http://purl.org/dc/terms/modified"),
+                literal(new Date(timestamps.updated).toISOString(), namedNode(XSD.dateTime)),
             ),
         );
 

--- a/src/ldes/Fragment.ts
+++ b/src/ldes/Fragment.ts
@@ -1,4 +1,4 @@
-import { CacheDirectives, DC, Member, RelationType } from "@treecg/types";
+import { CacheDirectives, Member, RelationType } from "@treecg/types";
 import type * as RDF from "@rdfjs/types";
 import { Parser } from "n3";
 
@@ -32,6 +32,11 @@ export interface RelationParameters {
     remainingItems?: number;
 }
 
+export interface Timestamps {
+    created: number,
+    updated: number,
+}
+
 /**
  * Interface representing a single Fragment.
  * A fragment contains zero or more members, zero or more relations and can be a view (all members are reachable from the current fragment)
@@ -41,12 +46,19 @@ export interface Fragment {
      * Fetch or return members from this fragment
      */
     getMembers(): Promise<Member[]>;
+
     /**
      * Fetch or return all relations starting from this fragment
      */
     getRelations(): Promise<RelationParameters[]>;
+
     /**
      * Fetch or return the cache directives concerning this fragment
      */
     getCacheDirectives(): Promise<CacheDirectives>;
+
+    /**
+     * Fetch or return timestamps for this fragment
+     */
+    getTimestamps(): Promise<Timestamps>;
 }

--- a/src/ldes/SDSFragment.ts
+++ b/src/ldes/SDSFragment.ts
@@ -1,5 +1,5 @@
 import { CacheDirectives, Member } from "@treecg/types";
-import { Fragment, RelationParameters } from "./Fragment";
+import { Fragment, RelationParameters, Timestamps } from "./Fragment";
 import { Repository } from "../repositories/Repository";
 
 export class SDSFragment implements Fragment {
@@ -9,16 +9,20 @@ export class SDSFragment implements Fragment {
 
     cacheDirectives: CacheDirectives;
 
+    timestamps: Timestamps;
+
     constructor(
         members: string[],
         relations: RelationParameters[],
         repository: Repository,
         cacheDirectives: CacheDirectives,
+        timestamps: Timestamps,
     ) {
         this.repository = repository;
         this.members = members;
         this.relations = relations;
         this.cacheDirectives = cacheDirectives;
+        this.timestamps = timestamps;
     }
 
     async getMembers(): Promise<Member[]> {
@@ -31,5 +35,9 @@ export class SDSFragment implements Fragment {
 
     async getCacheDirectives(): Promise<CacheDirectives> {
         return this.cacheDirectives;
+    }
+
+    async getTimestamps(): Promise<Timestamps> {
+        return this.timestamps;
     }
 }

--- a/src/ldes/SDSView.ts
+++ b/src/ldes/SDSView.ts
@@ -145,6 +145,7 @@ export class SDSView implements View {
             relations,
             this.repository,
             this.getCacheDirectives(fragment?.immutable),
+            { created: fragment.created, updated: fragment.updated },
         );
     }
 }

--- a/src/repositories/MongoDBRepository.ts
+++ b/src/repositories/MongoDBRepository.ts
@@ -68,6 +68,8 @@ export class MongoDBRepository implements Repository {
                     immutable: entry.immutable,
                     members: entry.members,
                     relations: entry.relations,
+                    created: entry.created,
+                    updated: entry.updated,
                 };
             }) ?? null;
     }

--- a/src/repositories/RedisRepository.ts
+++ b/src/repositories/RedisRepository.ts
@@ -66,6 +66,8 @@ export class RedisRepository implements Repository {
             immutable: doc.value.immutable as unknown as boolean,
             members: members,
             relations: relations,
+            created: doc.value.created as number,
+            updated: doc.value.updated as number,
         };
     }
 

--- a/src/repositories/Repository.ts
+++ b/src/repositories/Repository.ts
@@ -12,6 +12,8 @@ export type Bucket = {
     immutable?: boolean;
     members: string[];
     relations: Relation[];
+    created: number,
+    updated: number,
 };
 
 export type Relation = {


### PR DESCRIPTION
Counterpart of https://github.com/rdf-connect/sds-storage-writer-ts/pull/9
Will be used to measure latency during benchmarking

Appears in the LDES as follows (last 2 triples are new):
```turtle
<http://localhost:3000/ldes/default/root/2024-03-03T21%3A45%3A00.000Z_494100000_0> a <https://w3id.org/tree#Node>;
    <https://w3id.org/tree#viewDescription> <http://localhost:3000/ldes/#timestampFragmentation>;
    <http://purl.org/dc/terms/created> "2024-10-15T13:47:00.569Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
    <http://purl.org/dc/terms/modified> "2024-10-15T13:47:16.621Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>.
```