### PR TITLE
chore: Disable resource locker as ldes server is read-only

### DIFF
--- a/ingest/server.json
+++ b/ingest/server.json
@@ -32,7 +32,7 @@
     "css:config/util/index/default.json",
     "css:config/util/logging/winston.json",
     "css:config/util/representation-conversion/default.json",
-    "css:config/util/resource-locker/memory.json",
+    "css:config/util/resource-locker/debug-void.json",
     "css:config/util/variables/default.json"
   ],
   "@graph": [

--- a/server/examples/config-ldes-acl.json
+++ b/server/examples/config-ldes-acl.json
@@ -33,7 +33,7 @@
     "css:config/util/index/default.json",
     "css:config/util/logging/winston.json",
     "css:config/util/representation-conversion/default.json",
-    "css:config/util/resource-locker/memory.json",
+    "css:config/util/resource-locker/debug-void.json",
     "css:config/util/variables/default.json"
   ],
   "@graph": [

--- a/server/examples/config-ldes-bluebike.json
+++ b/server/examples/config-ldes-bluebike.json
@@ -33,7 +33,7 @@
         "css:config/util/index/default.json",
         "css:config/util/logging/winston.json",
         "css:config/util/representation-conversion/default.json",
-        "css:config/util/resource-locker/memory.json",
+        "css:config/util/resource-locker/debug-void.json",
         "css:config/util/variables/default.json"
     ],
     "@graph": [

--- a/server/examples/config-ldes-file_locks.json
+++ b/server/examples/config-ldes-file_locks.json
@@ -33,7 +33,7 @@
         "css:config/util/index/default.json",
         "css:config/util/logging/winston.json",
         "css:config/util/representation-conversion/default.json",
-        "css:config/util/resource-locker/memory.json",
+        "css:config/util/resource-locker/debug-void.json",
         "css:config/util/variables/default.json"
     ],
     "@graph": [

--- a/server/examples/config-ldes-rinf.json
+++ b/server/examples/config-ldes-rinf.json
@@ -33,7 +33,7 @@
         "css:config/util/index/default.json",
         "css:config/util/logging/winston.json",
         "css:config/util/representation-conversion/default.json",
-        "css:config/util/resource-locker/memory.json",
+        "css:config/util/resource-locker/debug-void.json",
         "css:config/util/variables/default.json"
     ],
     "@graph": [

--- a/server/examples/config-ldes.json
+++ b/server/examples/config-ldes.json
@@ -33,7 +33,7 @@
     "css:config/util/index/default.json",
     "css:config/util/logging/winston.json",
     "css:config/util/representation-conversion/default.json",
-    "css:config/util/resource-locker/memory.json",
+    "css:config/util/resource-locker/debug-void.json",
     "css:config/util/variables/default.json"
   ],
   "@graph": [

--- a/server/examples/config-sparql-store.json
+++ b/server/examples/config-sparql-store.json
@@ -33,7 +33,7 @@
         "css:config/util/index/default.json",
         "css:config/util/logging/winston.json",
         "css:config/util/representation-conversion/default.json",
-        "css:config/util/resource-locker/memory.json",
+        "css:config/util/resource-locker/debug-void.json",
         "css:config/util/variables/default.json"
     ],
     "@graph": [


### PR DESCRIPTION
This will improve the performance of the server when a lot of clients are simultaneously sending requests to the server.
Before, each client had to wait till a lock was achieved, before the request of the next client could be handled. With this change, this is no longer needed.
In my benchmark with 100 simultaneous clients, this already results in a big difference, as before it was practically impossible for the clients to retrieve results.